### PR TITLE
Support all two-tuples and literal :system tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ end
 
 Then, add it to the config providers of distillery in `rel/config.exs`
 
-``` elixir
+```elixir
 release :myapp do
   # ...snip...
   set config_providers: [
@@ -48,13 +48,22 @@ The available options are:
 - `default`: Default value if the environment variable is not setted. Default no `nil`
 - `transform`: Function to transform the final value, the syntax is {Module, :function}
 
+If you need to store the literal values `{:system, term()}`, `{:system, term(), Keyword.t()}`,
+you can use `{:system, :literal, term()}` to disable ConfigTuples config interpolation. For example:
+
+```elixir
+# This will store the value {:system, :foo}
+config :my_app,
+  value: {:system, :literal, {:system, :foo}}
+```
+
 ## Example
 
 This could be an example for Ecto repository and logger:
 
 ``` elixir
 config :my_app,
-    uri: {:system, "HOST", transform: {MyApp.UriParser, :parse}}
+  uri: {:system, "HOST", transform: {MyApp.UriParser, :parse}}
 
 config :my_app, MyApp.Repo,
   adapter: Ecto.Adapters.MySQL,

--- a/lib/provider.ex
+++ b/lib/provider.ex
@@ -73,12 +73,20 @@ defmodule ConfigTuples.Provider do
 
   defp replace_value({:system, env}), do: replace_value({:system, env, []})
 
+  defp replace_value({:system, :literal, value}) do
+    value
+  end
+
   defp replace_value({:system, env, opts}) do
     type = Keyword.get(opts, :type, :string)
     default = Keyword.get(opts, :default)
     transformer = Keyword.get(opts, :transform)
 
     env |> get_env_value(type, default) |> transform(transformer)
+  end
+
+  defp replace_value(other) do
+    other
   end
 
   defp get_env_value(env, type, default) do


### PR DESCRIPTION
This fixes a crash when using two-tuples without `:system`, for example:

```elixir
config :myapp, value: {Foo, :bar}
```

It also adds support for literal `{:system, :foo}` values in the config.