### PR TITLE
Fix the critical error on range params

### DIFF
--- a/lib/provider.ex
+++ b/lib/provider.ex
@@ -72,6 +72,10 @@ defmodule ConfigTuples.Provider do
   def replace({:system, value}), do: replace_value(value, [])
   def replace({:system, value, opts}), do: replace_value(value, opts)
 
+  def replace(from..to) do
+    from..to
+  end
+
   def replace(list) when is_list(list) do
     Enum.map(list, fn
       {key, value} -> {replace(key), replace(value)}

--- a/test/provider_test.exs
+++ b/test/provider_test.exs
@@ -15,7 +15,8 @@ defmodule ConfigTuples.ProviderTest do
         environment: :system,
         system: :production,
         port: 8080,
-        ssl: true
+        ssl: true,
+        some_range: 1..2
       ]
 
       env_scope(envs, config, fn ->


### PR DESCRIPTION
I've noticed that when you define a value of a parameter as a range, the config_tuples provider crashes fatally and the release is not able to start at all. That is because it things the range is a map (since it is a struct)

Since it is only possible to define a range with two integers, no replacements are possible in this case, however the provider should still not crash.