### PR TITLE
Ignore Regex structs

### DIFF
--- a/lib/provider.ex
+++ b/lib/provider.ex
@@ -112,6 +112,11 @@ defmodule ConfigTuples.Provider do
 
   def replace(%{__struct__: struct} = value) when struct in @ignore_structs, do: value
 
+  def replace(%{__struct__: struct} = value) do
+    values = value |> Map.from_struct() |> replace()
+    struct(struct, values)
+  end
+
   def replace(map) when is_map(map) do
     Map.new(map, fn
       {key, value} -> {replace(key), replace(value)}

--- a/lib/provider.ex
+++ b/lib/provider.ex
@@ -48,6 +48,8 @@ defmodule ConfigTuples.Provider do
     @behaviour Config.Provider
   end
 
+  @ignore_structs [Regex]
+
   def init(_cfg) do
     if use_distillery() do
       distillery_provider()
@@ -107,6 +109,8 @@ defmodule ConfigTuples.Provider do
       other -> replace(other)
     end)
   end
+
+  def replace(%{__struct__: struct} = value) when struct in @ignore_structs, do: value
 
   def replace(map) when is_map(map) do
     Map.new(map, fn

--- a/test/provider_elixir_test.exs
+++ b/test/provider_elixir_test.exs
@@ -8,6 +8,12 @@ defmodule ConfigTuples.ProviderElixirTest do
     :ok
   end
 
+  defmodule CustomStruct do
+    defstruct [:domain]
+  end
+
+  alias __MODULE__.CustomStruct
+
   describe "basic tests" do
     test "do not replace data without system tuple" do
       envs = %{}
@@ -238,6 +244,22 @@ defmodule ConfigTuples.ProviderElixirTest do
       expected_config = [
         host: "localhost",
         regex: ~r/.+/
+      ]
+
+      env_scope(envs, fn ->
+        assert_config(config, expected_config)
+      end)
+    end
+
+    test "does not ignore other structs" do
+      envs = %{"HOST" => "localhost"}
+
+      config = [
+        my_struct: %CustomStruct{domain: {:system, "HOST"}}
+      ]
+
+      expected_config = [
+        my_struct: %CustomStruct{domain: "localhost"}
       ]
 
       env_scope(envs, fn ->

--- a/test/provider_elixir_test.exs
+++ b/test/provider_elixir_test.exs
@@ -226,6 +226,26 @@ defmodule ConfigTuples.ProviderElixirTest do
     end
   end
 
+  describe "ignore structs" do
+    test "ignore regex structs" do
+      envs = %{"HOST" => "localhost"}
+
+      config = [
+        host: {:system, "HOST"},
+        regex: ~r/.+/
+      ]
+
+      expected_config = [
+        host: "localhost",
+        regex: ~r/.+/
+      ]
+
+      env_scope(envs, fn ->
+        assert_config(config, expected_config)
+      end)
+    end
+  end
+
   defp assert_config(config, expected) do
     config = [my_app: config]
     expected = [my_app: expected]

--- a/test/provider_test.exs
+++ b/test/provider_test.exs
@@ -240,6 +240,27 @@ defmodule ConfigTuples.ProviderTest do
     end
   end
 
+  describe "ignore structs" do
+    test "ignore regex structs" do
+      envs = %{"HOST" => "localhost"}
+
+      config = [
+        host: {:system, "HOST"},
+        regex: ~r/.+/
+      ]
+
+      expected_config = [
+        host: "localhost",
+        regex: ~r/.+/
+      ]
+
+      env_scope(envs, config, fn ->
+        Provider.init([])
+        assert_config(expected_config)
+      end)
+    end
+  end
+
   defp assert_config(config, app \\ @app) do
     config = config |> Keyword.to_list() |> Enum.sort()
 

--- a/test/provider_test.exs
+++ b/test/provider_test.exs
@@ -11,6 +11,12 @@ defmodule ConfigTuples.ProviderTest do
     :ok
   end
 
+  defmodule CustomStruct do
+    defstruct [:domain]
+  end
+
+  alias __MODULE__.CustomStruct
+
   describe "basic tests" do
     test "do not replace data without system tuple" do
       envs = %{}
@@ -252,6 +258,23 @@ defmodule ConfigTuples.ProviderTest do
       expected_config = [
         host: "localhost",
         regex: ~r/.+/
+      ]
+
+      env_scope(envs, config, fn ->
+        Provider.init([])
+        assert_config(expected_config)
+      end)
+    end
+
+    test "does not ignore other structs" do
+      envs = %{"HOST" => "localhost"}
+
+      config = [
+        my_struct: %CustomStruct{domain: {:system, "HOST"}}
+      ]
+
+      expected_config = [
+        my_struct: %CustomStruct{domain: "localhost"}
       ]
 
       env_scope(envs, config, fn ->


### PR DESCRIPTION
The Regex's are stored as structs, so right now ConfigTuples provider tries to replace the values, which of course doesn't work.

Let's ignore the `Regex` struct right now, and in the future we can add it as an option in the configuration so the users can provide custom structs to ignore.