### PR TITLE
Filter elixir config apps

### DIFF
--- a/lib/provider.ex
+++ b/lib/provider.ex
@@ -72,9 +72,15 @@ defmodule ConfigTuples.Provider do
   end
 
   defp elixir_provider(config) do
-    new_config = replace(config)
+    new_config = config |> filter_elixir_config() |> replace()
 
     deep_merge(config, new_config)
+  end
+
+  @elixir_apps [:elixir, :kernel]
+
+  defp filter_elixir_config(config) do
+    Keyword.drop(config, @elixir_apps)
   end
 
   defp fix_app_env(app) do


### PR DESCRIPTION
On elixir 1.10 they added a config value on the `:elixir` application that overlaps with our `:system` tuples, so let's just ignore the elixir application, we shouldn't be changing anything from them anyway.

``` elixir
[elixir: [
      config_providers: %Config.Provider{
        config_path: {:system, "RELEASE_SYS_CONFIG", ".config"},  # This one 
        extra_config: [kernel: [start_distribution: true]],
        providers: [{ConfigTuples.Provider, nil}],
        prune_after_boot: false,
        reboot_after_config: true
      }
    ]
]
```